### PR TITLE
Some updates

### DIFF
--- a/.cursor/skills/code-review/SKILL.md
+++ b/.cursor/skills/code-review/SKILL.md
@@ -1,0 +1,58 @@
+You are an Expert Staff Frontend Engineer performing a code review. Your goal is to ensure the code is robust, performant, accessible, and maintainable. You balance rigorous engineering standards with pragmatic delivery.
+
+TECH STACK CONTEXT:
+
+- Web Development (HTML5, CSS3, Modern Browser APIs)
+- TypeScript (Strict Mode)
+- JavaScript (ES6+)
+- React Ecosystem (Functional components, Hooks, Context)
+
+REVIEW GUIDELINES:
+
+1. TypeScript Rigor:
+
+- Flag any use of `any`. Suggest specific types, `unknown`, or generics.
+- Catch overly permissive types or missing return types on complex functions.
+- If a custom type/interface is missing from the provided context, point it out only if it obscures a potential bug.
+
+2. React Best Practices:
+
+- Enforce the Rules of Hooks (e.g., missing dependencies in `useEffect` or `useCallback`).
+- Identify unnecessary re-renders. Suggest `useMemo` or `useCallback` ONLY where it objectively improves performance. Do not prematurely optimize.
+- Flag anti-patterns (e.g., using indexes as keys, mutating state directly, derived state).
+
+3. Architecture & Clean Code:
+
+- Highlight components violating the Single Responsibility Principle.
+- Catch duplicated logic that should be extracted into custom hooks or utilities.
+- Flag "magic strings/numbers" and suggest constants.
+
+4. Web Vitals & Accessibility (a11y):
+
+- Flag missing `alt` tags, incorrect ARIA attributes, or non-semantic HTML.
+- Note potential performance bottlenecks (e.g., missing lazy loading for heavy components).
+
+5. Testing & Security:
+
+- If tests are provided, flag tests that check implementation details rather than user behavior.
+- Flag potential XSS vulnerabilities (e.g., `dangerouslySetInnerHTML`).
+
+OUTPUT FORMAT:
+Provide your review in structured Markdown. Use the following severity tags:
+
+- [BLOCKER]: Critical bug, security flaw, or massive anti-pattern. Must fix.
+- [SUGGESTION]: Strong recommendation for better performance, typing, or readability.
+- [NITPICK]: Minor styling, naming conventions, or formatting.
+- [QUESTION]: Use this if the provided code snippet is missing critical context (e.g., an imported hook or state shape) needed to accurately review it.
+
+For every issue found, provide:
+
+1. File name and line number (if applicable).
+2. A brief, objective explanation of _why_ it is an issue.
+3. A short, corrected code snippet demonstrating the fix (only the modified lines).
+
+TONE & BEHAVIOR:
+
+- Be objective, constructive, and concise.
+- UNDER NO CIRCUMSTANCES should you include introductory or concluding conversational filler (e.g., "Here is your review," "Great job," or "Let me know if you need help").
+- Output ONLY the structured review.

--- a/src/components/common/table-columns/BLOCK_COLUMNS.tsx
+++ b/src/components/common/table-columns/BLOCK_COLUMNS.tsx
@@ -35,7 +35,7 @@ export const BLOCK_COLUMNS = [
     id: 'extrinsicsCount',
     header: 'Extrinsics',
     cell: (props) => props.getValue(),
-    enableSorting: false
+    enableSorting: true
   }),
   columnHelper.accessor('reward', {
     id: 'reward',

--- a/src/components/common/table-columns/EXTRINSIC_COLUMNS.tsx
+++ b/src/components/common/table-columns/EXTRINSIC_COLUMNS.tsx
@@ -5,6 +5,7 @@ import { TimestampDisplay } from '@/components/ui/timestamp-display';
 import { RESOURCES } from '@/constants/resources';
 import { cn } from '@/lib/utils';
 import type { BlockExtrinsic } from '@/schemas/blocks';
+import { getExtrinsicDetailPath } from '@/utils/get-extrinsic-detail-path';
 import { formatMonetaryValue, formatTxAddress } from '@/utils/formatter';
 
 const columnHelper = createColumnHelper<BlockExtrinsic>();
@@ -26,32 +27,7 @@ export const createExtrinsicColumns = () => {
       cell: (props) => {
         const hash = props.getValue();
         const { pallet, call } = props.row.original;
-
-        // Determine the appropriate resource based on pallet
-        let href = '';
-        if (pallet === 'Wormhole') {
-          href = `${RESOURCES.wormhole}/${hash}`;
-        } else if (pallet === 'Balances') {
-          href = `${RESOURCES.transactions}/${hash}`;
-        } else if (
-          pallet === 'ReversibleTransfers' &&
-          call === 'schedule_transfer'
-        ) {
-          href = `${RESOURCES.scheduledReversibleTransactions}/${hash}`;
-        } else if (
-          pallet === 'ReversibleTransfers' &&
-          call === 'execute_transfer'
-        ) {
-          href = `${RESOURCES.executedReversibleTransactions}/${hash}`;
-        } else if (
-          pallet === 'ReversibleTransfers' &&
-          call === 'cancel_transfer'
-        ) {
-          href = `${RESOURCES.cancelledReversibleTransactions}/${hash}`;
-        } else {
-          // Default to transactions for now
-          href = `${RESOURCES.transactions}/${hash}`;
-        }
+        const href = getExtrinsicDetailPath({ id: hash, pallet, call });
 
         return (
           <LinkWithCopy

--- a/src/components/common/table-columns/TRANSACTION_COLUMNS.tsx
+++ b/src/components/common/table-columns/TRANSACTION_COLUMNS.tsx
@@ -4,6 +4,7 @@ import { LinkWithCopy } from '@/components/ui/composites/link-with-copy/LinkWith
 import { TimestampDisplay } from '@/components/ui/timestamp-display';
 import { RESOURCES } from '@/constants/resources';
 import type { Transaction } from '@/schemas';
+import { getExtrinsicDetailPath } from '@/utils/get-extrinsic-detail-path';
 import { formatMonetaryValue, formatTxAddress } from '@/utils/formatter';
 
 const columnHelper = createColumnHelper<Transaction>();
@@ -12,16 +13,26 @@ export const TRANSACTION_COLUMNS = [
   columnHelper.accessor('extrinsic.id', {
     id: 'tx-hash',
     header: 'Hash',
-    cell: (props) =>
-      props.getValue() ? (
+    cell: (props) => {
+      const extrinsicId = props.getValue();
+      const extrinsic = props.row.original.extrinsic;
+
+      if (!extrinsicId || !extrinsic?.pallet || !extrinsic?.call) {
+        return 'Is not available';
+      }
+
+      return (
         <LinkWithCopy
-          href={`${RESOURCES.transactions}/${props.getValue()}`}
-          text={formatTxAddress(props.getValue() ?? '-')}
-          textCopy={props.getValue() ?? ''}
+          href={getExtrinsicDetailPath({
+            id: extrinsicId,
+            pallet: extrinsic.pallet,
+            call: extrinsic.call
+          })}
+          text={formatTxAddress(extrinsicId)}
+          textCopy={extrinsicId}
         />
-      ) : (
-        'Is not available'
-      ),
+      );
+    },
     enableSorting: false
   }),
   columnHelper.accessor('block.height', {

--- a/src/components/features/block-listing/blocks-table/hook.tsx
+++ b/src/components/features/block-listing/blocks-table/hook.tsx
@@ -5,8 +5,7 @@ import useApiClient from '@/api';
 import { BLOCK_COLUMNS } from '@/components/common/table-columns/BLOCK_COLUMNS';
 import { DATA_POOL_INTERVAL } from '@/constants/data-pool-interval';
 import { QUERY_DEFAULT_LIMIT } from '@/constants/query-default-limit';
-import type { BlockSorts } from '@/constants/query-sorts';
-import { useOrderBy } from '@/hooks/useOrderBy';
+import { transformBlockOrderBy } from '@/constants/query-sorts';
 import { useTableState } from '@/hooks/useTableState';
 import type { Block } from '@/schemas';
 import { transformSortLiteral } from '@/utils/transform-sort';
@@ -22,7 +21,10 @@ export const useBlocksTable = () => {
     paginationValue
   } = useTableState('timestamp:desc', QUERY_DEFAULT_LIMIT);
 
-  const orderByObject = useOrderBy<BlockSorts>(orderBy ?? 'timestamp:desc');
+  const orderByObject = useMemo(
+    () => transformBlockOrderBy(orderBy ?? 'timestamp:desc'),
+    [orderBy]
+  );
   const sortingValue = transformSortLiteral(orderBy);
 
   const {

--- a/src/components/features/landing/block-tables/hook.tsx
+++ b/src/components/features/landing/block-tables/hook.tsx
@@ -4,8 +4,7 @@ import { useMemo } from 'react';
 import useApiClient from '@/api';
 import { BLOCK_COLUMNS } from '@/components/common/table-columns/BLOCK_COLUMNS';
 import { DATA_POOL_INTERVAL } from '@/constants/data-pool-interval';
-import type { BlockSorts } from '@/constants/query-sorts';
-import { useOrderBy } from '@/hooks/useOrderBy';
+import { transformBlockOrderBy } from '@/constants/query-sorts';
 import { useTableState } from '@/hooks/useTableState';
 import type { Block } from '@/schemas';
 import { transformSortLiteral } from '@/utils/transform-sort';
@@ -21,7 +20,10 @@ export const useBlocksTable = () => {
     paginationValue
   } = useTableState('timestamp:desc');
 
-  const orderByObject = useOrderBy<BlockSorts>(orderBy ?? 'timestamp:desc');
+  const orderByObject = useMemo(
+    () => transformBlockOrderBy(orderBy ?? 'timestamp:desc'),
+    [orderBy]
+  );
   const sortingValue = transformSortLiteral(orderBy);
 
   const {

--- a/src/components/features/transaction-details/transaction-information/TransactionInformation.tsx
+++ b/src/components/features/transaction-details/transaction-information/TransactionInformation.tsx
@@ -1,4 +1,4 @@
-import { notFound } from '@tanstack/react-router';
+import { notFound, useNavigate } from '@tanstack/react-router';
 import { getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import * as React from 'react';
 
@@ -12,6 +12,7 @@ import { RESOURCES } from '@/constants/resources';
 import { cn } from '@/lib/utils';
 import type { ExtrinsicDetail, ExtrinsicTransfer } from '@/schemas';
 import { formatMonetaryValue, formatTimestamp } from '@/utils/formatter';
+import { isWormholeExtrinsic } from '@/utils/get-extrinsic-detail-path';
 
 export interface TransactionInformationProps {
   hash: string;
@@ -21,16 +22,29 @@ export const TransactionInformation: React.FC<TransactionInformationProps> = ({
   hash
 }) => {
   const api = useApiClient();
+  const navigate = useNavigate();
   const { data, loading } = api.transactions.getByHash().useQuery(hash);
 
-  if (!loading && (!data || data.extrinsics.length === 0)) throw notFound();
+  const extrinsic = data?.extrinsics[0];
+
+  const isRedirectingToWormhole =
+    !loading && !!extrinsic && isWormholeExtrinsic(extrinsic);
+
+  React.useEffect(() => {
+    if (!isRedirectingToWormhole) return;
+
+    navigate({
+      to: '/wormhole/$id',
+      params: { id: hash },
+      replace: true
+    });
+  }, [isRedirectingToWormhole, hash, navigate]);
 
   const extrinsicTransactionColumns = React.useMemo(
     () => EXTRINSIC_TRANSACTION_COLUMNS,
     []
   );
 
-  const extrinsic = data?.extrinsics[0];
   const transfers = data?.transfers ?? [];
   const table = useReactTable<ExtrinsicTransfer>({
     data: transfers,
@@ -39,6 +53,12 @@ export const TransactionInformation: React.FC<TransactionInformationProps> = ({
     manualSorting: true,
     manualPagination: true
   });
+
+  if (!loading && (!data || data.extrinsics.length === 0)) throw notFound();
+
+  if (isRedirectingToWormhole) {
+    return null;
+  }
 
   const extrinsicInfo: Partial<ExtrinsicDetail>[] = [
     {

--- a/src/components/features/wormhole/WormholeOutputDetails.tsx
+++ b/src/components/features/wormhole/WormholeOutputDetails.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { DataList } from '@/components/ui/composites/data-list/DataList';
 import { LinkWithCopy } from '@/components/ui/composites/link-with-copy/LinkWithCopy';
 import { TextWithCopy } from '@/components/ui/composites/text-with-copy/TextWithCopy';
+import { Skeleton } from '@/components/ui/skeleton';
 import { RESOURCES } from '@/constants/resources';
 import { formatMonetaryValue, formatTimestamp } from '@/utils/formatter';
 
@@ -38,6 +39,11 @@ export const WormholeOutputInformation = ({
   const nullifiers = data?.wormholeNullifiers ?? [];
 
   if (!loading && !extrinsic) throw notFound();
+
+  const outputs = extrinsic?.outputs ?? [];
+  const showExitOutputs = loading || outputs.length > 0;
+  const showNullifiers = loading || nullifiers.length > 0;
+  const nullifierCount = loading ? 16 : nullifiers.length;
 
   const extrinsicInfo: Partial<ExtrinsicInfo>[] = [
     {
@@ -161,97 +167,112 @@ export const WormholeOutputInformation = ({
         ]}
       />
 
-      <h2 className="text-lg font-semibold">Exit Outputs</h2>
-      {loading ? (
-        <Card>
-          <CardContent className="p-4">
-            <div className="animate-pulse space-y-3">
-              <div className="h-12 rounded bg-muted" />
-              <div className="h-12 rounded bg-muted" />
-            </div>
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="flex flex-col gap-3">
-          {extrinsic?.outputs?.map(
-            (
-              output: {
-                id: string;
-                exitAccount: { id: string };
-                amount: string;
-              },
-              idx: number
-            ) => (
-              <Card key={output.id}>
+      {showExitOutputs && (
+        <>
+          <h2 className="text-lg font-semibold">Exit Outputs</h2>
+          <div className="flex flex-col gap-4">
+            {(loading ? [null] : outputs).map((output, idx) => (
+              <Card key={loading ? 'loading' : output!.id}>
                 <CardContent className="p-4">
                   <dl className="grid grid-cols-1 gap-y-2">
                     <div className="grid grid-cols-1 items-center lg:grid-cols-[300px_1fr]">
                       <dt className="font-medium text-muted-foreground">
-                        Output {idx + 1} of {extrinsic.output_count}
+                        {loading ? (
+                          <Skeleton className="h-6 w-36" />
+                        ) : (
+                          `Output ${idx + 1} of ${extrinsic!.output_count}`
+                        )}
                       </dt>
-                      <dd>{formatMonetaryValue(output.amount)}</dd>
+                      {loading ? (
+                        <Skeleton className="h-6" />
+                      ) : (
+                        <dd>{formatMonetaryValue(output!.amount)}</dd>
+                      )}
                     </div>
                     <div className="grid grid-cols-1 items-center lg:grid-cols-[300px_1fr]">
                       <dt className="font-medium text-muted-foreground">
                         Exit Account
                       </dt>
-                      <dd>
-                        <LinkWithCopy
-                          href={`${RESOURCES.accounts}/${output.exitAccount.id}`}
-                          text={output.exitAccount.id}
-                          className="break-all"
-                        />
-                      </dd>
+                      {loading ? (
+                        <Skeleton className="h-6" />
+                      ) : (
+                        <dd>
+                          <LinkWithCopy
+                            href={`${RESOURCES.accounts}/${output!.exitAccount.id}`}
+                            text={output!.exitAccount.id}
+                            className="break-all"
+                          />
+                        </dd>
+                      )}
                     </div>
                   </dl>
                 </CardContent>
               </Card>
-            )
-          )}
-        </div>
+            ))}
+          </div>
+        </>
       )}
 
-      {nullifiers.length > 0 && (
+      {showNullifiers && (
         <>
           <h2 className="text-lg font-semibold">Nullifiers</h2>
           <Card>
             <CardContent className="p-4">
               <p className="mb-3 text-sm text-muted-foreground">
-                {nullifiers.length} nullifier
-                {nullifiers.length !== 1 ? 's' : ''} consumed by this proof
+                {nullifierCount} nullifier
+                {nullifierCount !== 1 ? 's' : ''} consumed by this proof
                 verification. Each corresponds to a spent wormhole deposit.
               </p>
               <div className="space-y-2">
-                {nullifiers.map(
-                  (
-                    n: { nullifier: string; nullifier_hash: string },
-                    idx: number
-                  ) => (
-                    <div key={idx} className="rounded border p-2">
-                      <dl className="grid grid-cols-1 gap-y-1">
-                        <div className="grid grid-cols-1 items-center lg:grid-cols-[300px_1fr]">
-                          <dt className="text-sm font-medium text-muted-foreground">
-                            Nullifier {idx + 1}
-                          </dt>
-                          <dd>
-                            <TextWithCopy
-                              text={n.nullifier}
-                              className="break-all text-xs"
-                            />
-                          </dd>
+                {loading
+                  ? Array.from({ length: 16 }, (_, idx) => (
+                      <div key={idx} className="rounded border p-2">
+                        <dl className="grid grid-cols-1 gap-y-1">
+                          <div className="grid grid-cols-1 items-center lg:grid-cols-[300px_1fr]">
+                            <dt className="text-sm font-medium text-muted-foreground">
+                              Nullifier {idx + 1}
+                            </dt>
+                            <Skeleton className="h-6" />
+                          </div>
+                          <div className="grid grid-cols-1 items-center lg:grid-cols-[300px_1fr]">
+                            <dt className="text-sm font-medium text-muted-foreground">
+                              Hash (blake3)
+                            </dt>
+                            <Skeleton className="h-6" />
+                          </div>
+                        </dl>
+                      </div>
+                    ))
+                  : nullifiers.map(
+                      (
+                        n: { nullifier: string; nullifier_hash: string },
+                        idx: number
+                      ) => (
+                        <div key={idx} className="rounded border p-2">
+                          <dl className="grid grid-cols-1 gap-y-1">
+                            <div className="grid grid-cols-1 items-center lg:grid-cols-[300px_1fr]">
+                              <dt className="text-sm font-medium text-muted-foreground">
+                                Nullifier {idx + 1}
+                              </dt>
+                              <dd>
+                                <TextWithCopy
+                                  text={n.nullifier}
+                                  className="break-all text-xs"
+                                />
+                              </dd>
+                            </div>
+                            <div className="grid grid-cols-1 items-center lg:grid-cols-[300px_1fr]">
+                              <dt className="text-sm font-medium text-muted-foreground">
+                                Hash (blake3)
+                              </dt>
+                              <dd className="break-all text-xs text-muted-foreground">
+                                {n.nullifier_hash}
+                              </dd>
+                            </div>
+                          </dl>
                         </div>
-                        <div className="grid grid-cols-1 items-center lg:grid-cols-[300px_1fr]">
-                          <dt className="text-sm font-medium text-muted-foreground">
-                            Hash (blake3)
-                          </dt>
-                          <dd className="break-all text-xs text-muted-foreground">
-                            {n.nullifier_hash}
-                          </dd>
-                        </div>
-                      </dl>
-                    </div>
-                  )
-                )}
+                      )
+                    )}
               </div>
             </CardContent>
           </Card>

--- a/src/components/ui/composites/search-preview/SearchPreview.tsx
+++ b/src/components/ui/composites/search-preview/SearchPreview.tsx
@@ -5,6 +5,7 @@ import React, { forwardRef } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { RESOURCES } from '@/constants/resources';
 import type { SearchAllResponse } from '@/schemas/searchs';
+import { getExtrinsicDetailPath } from '@/utils/get-extrinsic-detail-path';
 
 import { Card, CardContent } from '../../card';
 
@@ -133,13 +134,21 @@ export const SearchPreview = forwardRef<HTMLDivElement, SearchPreviewProps>(
         title: 'Transactions',
         emptyMsg: 'No transactions found.',
         items: transactions,
-        renderItem: (tx: any) => (
-          <PreviewLink
-            href={`${RESOURCES.transactions}/${tx.extrinsic?.id}`}
-            label={`${tx.extrinsic?.id}`}
-            onSelect={handleClosePreview}
-          />
-        )
+        renderItem: (tx: any) => {
+          const { id, pallet, call } = tx.extrinsic ?? {};
+          const href =
+            id && pallet && call
+              ? getExtrinsicDetailPath({ id, pallet, call })
+              : `${RESOURCES.transactions}/${id}`;
+
+          return (
+            <PreviewLink
+              href={href}
+              label={`${id}`}
+              onSelect={handleClosePreview}
+            />
+          );
+        }
       },
       {
         title: 'Scheduled Reversible Transactions',

--- a/src/constants/query-sorts/blocks.ts
+++ b/src/constants/query-sorts/blocks.ts
@@ -6,6 +6,9 @@ export interface BlockSorts {
   height?: SortDirection;
   reward?: SortDirection;
   timestamp?: SortDirection;
+  extrinsics_aggregate?: {
+    count?: SortDirection;
+  };
 }
 
 export const BLOCK_SORTS_LITERALS = [
@@ -14,9 +17,30 @@ export const BLOCK_SORTS_LITERALS = [
   'height:desc',
   'reward:desc',
   'timestamp:desc',
+  'extrinsicsCount:desc',
   'id:asc',
   'hash:asc',
   'height:asc',
   'reward:asc',
-  'timestamp:asc'
+  'timestamp:asc',
+  'extrinsicsCount:asc'
 ];
+
+export const transformBlockOrderBy = (
+  orderBy: string
+): BlockSorts | undefined => {
+  const [key, order] = orderBy.split(':');
+  if (!key || !order) return undefined;
+
+  if (key === 'extrinsicsCount') {
+    return {
+      extrinsics_aggregate: {
+        count: order as SortDirection
+      }
+    };
+  }
+
+  return {
+    [key]: order
+  } as BlockSorts;
+};

--- a/src/utils/get-extrinsic-detail-path.ts
+++ b/src/utils/get-extrinsic-detail-path.ts
@@ -1,0 +1,39 @@
+import { RESOURCES } from '@/constants/resources';
+
+export interface ExtrinsicRouteInput {
+  id: string;
+  pallet: string;
+  call: string;
+}
+
+export const isWormholeExtrinsic = ({
+  pallet
+}: Pick<ExtrinsicRouteInput, 'pallet'>) => pallet === 'Wormhole';
+
+export const getExtrinsicDetailPath = ({
+  id,
+  pallet,
+  call
+}: ExtrinsicRouteInput): string => {
+  if (isWormholeExtrinsic({ pallet })) {
+    return `${RESOURCES.wormhole}/${id}`;
+  }
+
+  if (pallet === 'Balances') {
+    return `${RESOURCES.transactions}/${id}`;
+  }
+
+  if (pallet === 'ReversibleTransfers' && call === 'schedule_transfer') {
+    return `${RESOURCES.scheduledReversibleTransactions}/${id}`;
+  }
+
+  if (pallet === 'ReversibleTransfers' && call === 'execute_transfer') {
+    return `${RESOURCES.executedReversibleTransactions}/${id}`;
+  }
+
+  if (pallet === 'ReversibleTransfers' && call === 'cancel_transfer') {
+    return `${RESOURCES.cancelledReversibleTransactions}/${id}`;
+  }
+
+  return `${RESOURCES.transactions}/${id}`;
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI and navigation changes with shared routing logic; wormhole redirect is user-visible but localized and uses replace navigation.
> 
> **Overview**
> Centralizes **extrinsic deep-linking** in `getExtrinsicDetailPath` (wormhole, balances, reversible transfer calls) and wires it through extrinsic/transaction table columns and search preview, so links land on the right detail route instead of always using the generic transaction URL.
> 
> **Block tables** can now sort by extrinsic count: the column enables sorting, `BlockSorts` gains `extrinsics_aggregate.count`, and block listing hooks use `transformBlockOrderBy` instead of `useOrderBy` so `extrinsicsCount:asc|desc` maps to the API shape.
> 
> **Transaction detail** redirects wormhole extrinsics to `/wormhole/$id` with `replace: true` while data loads. **Wormhole output details** show skeleton placeholders during load and only render exit outputs / nullifiers sections when loading or data exists (including a fixed nullifier skeleton count while loading).
> 
> Also adds a **`.cursor/skills/code-review`** skill file (review guidelines only; no runtime behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0422ba214761bca7e942595660b4da764c7147d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->